### PR TITLE
Mock out remarkPluginFrontmatter in astro:content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
     The Unreleased block will also be used for the GitHub release notes.
 -->
 
+## 0.0.13
+
+* Improved compatibility for `astro:content` in component editable regions. The `render` function now returns the collection entry's frontmatter as `remarkPluginFrontmatter` instead of an empty object.
+
 ## 0.0.11
 
 * Fixed an issue where component editable regions wouldn't correctly update the tag name of child editable regions.

--- a/integrations/astro/modules/content.js
+++ b/integrations/astro/modules/content.js
@@ -36,7 +36,7 @@ export const getCollection = async (collectionKey, filter) => {
 			render: () => ({
 				Content: () => body ?? "Content is not available when live editing",
 				headings: [],
-				remarkPluginFrontmatter: {},
+				remarkPluginFrontmatter: data ?? {},
 			}),
 		};
 	});
@@ -109,7 +109,7 @@ export const getEntryBySlug = (collection, slug) => {
 export const render = async (entry) => ({
 	Content: () => entry?.body ?? "Content is not available when live editing",
 	headings: [],
-	remarkPluginFrontmatter: {},
+	remarkPluginFrontmatter: entry?.data ?? {},
 });
 
 export const defineCollection = () =>


### PR DESCRIPTION
* Improved compatibility for `astro:content` in component editable regions. The `render` function now returns the collection entry's frontmatter as `remarkPluginFrontmatter` instead of an empty object.